### PR TITLE
Retry (once) on error

### DIFF
--- a/lib/shopify.js
+++ b/lib/shopify.js
@@ -84,7 +84,11 @@ ShopifyAPI.prototype.hostname = function () {
   return this.config.shop.split(".")[0] + '.myshopify.com';
 };
 
-ShopifyAPI.prototype.makeRequest = function(endpoint, method, data, callback) {
+ShopifyAPI.prototype.port = function () {
+  return 443;
+};
+
+ShopifyAPI.prototype.makeRequest = function(endpoint, method, data, callback, retry) {
 
     var https = require('https'),
         dataString = JSON.stringify(data),
@@ -92,7 +96,7 @@ ShopifyAPI.prototype.makeRequest = function(endpoint, method, data, callback) {
             hostname: this.hostname(),
             path: endpoint,
             method: method.toLowerCase() || 'get',
-            port: 443,
+            port: this.port(),
             headers: {
                 'Content-Type': 'application/json',
                 'X-Shopify-Access-Token': this.config.access_token
@@ -157,7 +161,16 @@ ShopifyAPI.prototype.makeRequest = function(endpoint, method, data, callback) {
     });
 
     request.on('error', function(e){
-        callback(e);
+        self.conditional_console_log( "Request Error: ", e );
+        if(self.config.retry_errors && !retry){
+            var delay = self.config.error_retry_delay || 10000;
+            self.conditional_console_log( "retrying once in " + delay + " milliseconds" );
+            setTimeout(function() {
+                self.makeRequest(endpoint, method, data, callback, true);
+            }, delay );
+        } else{
+            callback(e);
+        }
     });
 
     if (options.method === 'post' || options.method === 'put' || options.method === 'delete') {


### PR DESCRIPTION
I did a single retry because it increases reliability sufficiently for me, but multiple retries could be done without persistent state just by using a counter for the retry param instead of a boolean.

I extracted hostname & port to methods so that I could use sinon while writing some tests of bad network connections in the code I'm writing that uses shopify-node-api.
