### PR TITLE
Allow delete request without callback.

### DIFF
--- a/lib/shopify.js
+++ b/lib/shopify.js
@@ -198,9 +198,14 @@ ShopifyAPI.prototype.put = function(endpoint, data, callback) {
 };
 
 ShopifyAPI.prototype.delete = function(endpoint, data, callback) {
-    if (typeof data === 'function' && arguments.length < 3) {
-        callback = data;
-        data = null;
+    if (arguments.length < 3) {
+        if (typeof data === 'function') {
+            callback = data;
+            data = null;
+        } else {
+            callback = new Function;
+            data = typeof data === 'undefined' ? null : data;
+        }
     }
     this.makeRequest(endpoint, 'DELETE', data, callback);
 };


### PR DESCRIPTION
'DELETE' requests cause an error if no callback is given. I altered the delete method to allow the callback argument to be left undefined.

it can now be called as

``` javascript
Shopify.delete('/admin/product/1234567.json');
```

This is handy for prototyping.
