### PR TITLE
fixed invalid content-length in request headers when using multibyte utf-8 characters

### DIFF
--- a/lib/shopify.js
+++ b/lib/shopify.js
@@ -91,7 +91,7 @@ ShopifyAPI.prototype.port = function () {
 ShopifyAPI.prototype.makeRequest = function(endpoint, method, data, callback, retry) {
 
     var https = require('https'),
-        dataString = JSON.stringify(data),
+        dataBuffer = new Buffer(JSON.stringify(data)),
         options = {
             hostname: this.hostname(),
             path: endpoint,
@@ -105,7 +105,7 @@ ShopifyAPI.prototype.makeRequest = function(endpoint, method, data, callback, re
         self = this;
 
     if (options.method === 'post' || options.method === 'put' || options.method === 'delete') {
-        options.headers['Content-Length'] = dataString.length;
+        options.headers['Content-Length'] = dataBuffer.length;
     }
 
     var request = https.request(options, function(response){
@@ -173,12 +173,9 @@ ShopifyAPI.prototype.makeRequest = function(endpoint, method, data, callback, re
         }
     });
 
-    if (options.method === 'post' || options.method === 'put' || options.method === 'delete') {
-        request.write(JSON.stringify(data));
-    }
 
-    request.end();
-
+    if (options.method === 'post' || options.method === 'put' || options.method === 'delete') request.end(dataBuffer);
+    else request.end();
 };
 
 ShopifyAPI.prototype.get = function(endpoint, data, callback) {


### PR DESCRIPTION
The http request header content-length should contain the byte and not the string length. 
