### PR TITLE
Add HTTP statusCode to Error Callback, conditional log for api limit

### DIFF
--- a/lib/shopify.js
+++ b/lib/shopify.js
@@ -112,8 +112,8 @@ ShopifyAPI.prototype.makeRequest = function(endpoint, method, data, callback, re
         self.conditional_console_log( 'STATUS: ' + response.statusCode );
         self.conditional_console_log( 'HEADERS: ' + JSON.stringify(response.headers) );
 
-        if (response.headers&&response.headers.http_x_shopify_shop_api_call_limit) {
-          self.conditional_console_log( 'API_LIMIT: ' + response.headers.http_x_shopify_shop_api_call_limit);
+        if (response.headers && response.headers.http_x_shopify_shop_api_call_limit) {
+            self.conditional_console_log( 'API_LIMIT: ' + response.headers.http_x_shopify_shop_api_call_limit);
         }
 
         response.setEncoding('utf8');
@@ -146,13 +146,13 @@ ShopifyAPI.prototype.makeRequest = function(endpoint, method, data, callback, re
                 try {
                     var json = {};
                     if (body.trim() != '') { //on some requests, Shopify retuns an empty body (several spaces)
-                      json = JSON.parse(body);
-                      if (json.hasOwnProperty('error') || json.hasOwnProperty('errors')) {
-                        return callback({
-                          error: (json.error || json.errors),
-                          code: response.statusCode
-                        });
-                      }
+                        json = JSON.parse(body);
+                        if (json.hasOwnProperty('error') || json.hasOwnProperty('errors')) {
+                            return callback({
+                                error: (json.error || json.errors),
+                                code: response.statusCode
+                            });
+                        }
                     }
                     callback(null, json, response.headers);
                 } catch(e) {


### PR DESCRIPTION
_What does this PR do?_
1. I found it odd that when i include `verbose: false` in the config object that this would still log the `response.headers.http_x_shopify_shop_api_call_limit` - maybe there was a discussion previously about this but it seemed like something that should also be conditionally logged
1. When i make an API call, i like to have the http statusCode so that i can more easily map api errors to interactions on my web service. I shouldn't have to parse the string to do that.
