### PR TITLE
Fix makeRequest for newer node versions

### DIFF
--- a/lib/shopify.js
+++ b/lib/shopify.js
@@ -98,11 +98,14 @@ ShopifyAPI.prototype.makeRequest = function(endpoint, method, data, callback, re
             method: method.toLowerCase() || 'get',
             port: this.port(),
             headers: {
-                'Content-Type': 'application/json',
-                'X-Shopify-Access-Token': this.config.access_token
+                'Content-Type': 'application/json'
             }
         },
         self = this;
+
+    if (this.config.access_token) {
+      options.headers['X-Shopify-Access-Token'] = this.config.access_token;
+    }
 
     if (options.method === 'post' || options.method === 'put' || options.method === 'delete') {
         options.headers['Content-Length'] = new Buffer(dataString).length;

--- a/test/shopify.js
+++ b/test/shopify.js
@@ -88,6 +88,40 @@ describe('#is_valid_signature', function(){
     });
 });
 
+describe('#exchange_temporary_token', function(){
+    it('should exchange a temporary token', function(done){
+
+        // Values used below were pre-calculated and not part
+        // of an actual shop.
+
+        var Shopify = shopifyAPI({
+                shop: 'myshop',
+                shopify_api_key: 'abc123',
+                shopify_shared_secret: 'asdf1234',
+                verbose: false
+            }),
+            params = {
+                code: 'di389so32hwh28923823dh3289329hdd',
+                timestamp: '1402539839',
+                signature: '679edfa2ebd05b2abcbb15b7fdc72934'
+            };
+
+        var shopifyTokenFetch = nock('https://myshop.myshopify.com')
+            .post('/admin/oauth/access_token')
+            .reply(200, {
+                "access_token": "abcd"
+            });
+
+        Shopify.exchange_temporary_token(params, function(err, res) {
+          if (err) {
+            return done(err);
+          }
+          shopifyTokenFetch.done();
+          done();
+        });
+    });
+});
+
 describe('#get', function(){
    it('should return correct response', function(done){
 


### PR DESCRIPTION
This PR fixes an issue that started occurring after upgrading to Node 0.12.0.

## The problem
The following error was seen in production
```
'Error: "name" and "value" are required for setHeader().', '
  at ClientRequest.OutgoingMessage.setHeader (_http_outgoing.js:333:11)', '
  at new ClientRequest (_http_client.js:101:14)', '
  at Object.exports.request (http.js:49:10)', '
  at Object.exports.request (https.js:136:15)', '
  at ShopifyAPI.makeRequest (/app/node_modules/shopify-node-api/lib/shopify.js:111:25)', ' 
  at ShopifyAPI.exchange_temporary_token (/app/node_modules/shopify-node-api/lib/shopify.js:73:10)',
```

## The reason
When exchanging a temporary Shopify token for a permanent, the `config` object does not yet have `access_token` so the `X-Shopify-Access-Token` header gets set to `undefined` which throws an error in Node due to:
https://github.com/joyent/node/blob/d8baf8a2a4481940bfed0196308ae6189ca18eee/lib/_http_outgoing.js#L332-333

## The solution
This PR :smile: 

Notice that the extra supplied test does not directly show the erroneous behavior because `nock` works ok with the `undefined` header. Commenting out the nock will throw the error (if the patch has not been applied yet of course)

Thank you for maintaining this library.