### PR TITLE
Add Accept header, fix oauth error callback

### DIFF
--- a/lib/shopify.js
+++ b/lib/shopify.js
@@ -80,7 +80,12 @@ ShopifyAPI.prototype.exchange_temporary_token = function(query_params, callback)
 
     this.makeRequest('/admin/oauth/access_token', 'POST', data, function(err, body){
 
-        if (err) return callback(new Error(err));
+        if (err) {
+          // err is either already an Error or it is a JSON object with an
+          // error field.
+          if (err.error) return callback(new Error(err.error));
+          return callback(err);
+        }
 
         self.set_access_token(body['access_token']);
         callback(null, body);
@@ -106,7 +111,8 @@ ShopifyAPI.prototype.makeRequest = function(endpoint, method, data, callback, re
             method: method.toLowerCase() || 'get',
             port: this.port(),
             headers: {
-                'Content-Type': 'application/json'
+                'Content-Type': 'application/json',
+                'Accept': 'application/json'
             }
         },
         self = this;


### PR DESCRIPTION
This PR fixes two small issues:

1. It adds an explicit `Accept` header to ensure that all API calls returns JSON data.
2. It makes sure that the `Error` constructor is not called with an object.

We noticed that the oauth API call in `exchange_temporary_token` returns an HTML answer when there is an error in the request. This can happen when the code cannot be successfully exchanged (for example if it has been used twice). This results in JSON parse error "Unexpected token <". Adding an explicit `Accept` header ensures that the response is valid JSON. It can be confirmed with these calls, for example:

    $ curl -i -X POST https://myshop.myshopify.com/admin/oauth/access_token
    $ curl -i -X POST https://myshop.com/admin/oauth/access_token -H 'Accept: application/json'

Also, the error returned by `makeRequest` is either a JSON object or an actual `Error` so using `new Error(err)` resulted in errors with messages such as "[object Object]". Now we'll have a better message :smiley: 