### PR TITLE
Added basic auth option for private apps

### DIFF
--- a/lib/shopify.js
+++ b/lib/shopify.js
@@ -119,6 +119,9 @@ ShopifyAPI.prototype.makeRequest = function(endpoint, method, data, callback, re
 
     if (this.config.access_token) {
       options.headers['X-Shopify-Access-Token'] = this.config.access_token;
+    } else if (this.config.private_app && this.config.shopify_api_key && this.config.shopify_api_password) {
+        options.headers['Authorization'] = 'Basic ' + new Buffer(this.config.shopify_api_key +
+                ':' + this.config.shopify_api_password).toString('base64');
     }
 
     if (options.method === 'post' || options.method === 'put' || options.method === 'delete') {


### PR DESCRIPTION
Shopify private apps don't accept access tokens. They use the API Key + Password basic auth instead.