### PR TITLE
Allow is_valid_signature to validate a signature without a state param

### DIFF
--- a/README.md
+++ b/README.md
@@ -229,6 +229,13 @@ You can call it from an initialized Shopify object like so
 Shopify.is_valid_signature(query_params);
 ~~~
 
+To verify a Shopify signature that does not contain a state parameter, just pass true as the second argument of `is_valid_signature`:
+
+~~~
+Shopify.is_valid_signature(query_params, true);
+~~~
+*This is required when checking a non-authorization query string, for example the query string passed when the app is clicked in the user's app store*
+
 ### API Call Limit Options
 
 By default, shopify-node-api will automatically wait if you approach Shopify's API call limit. The default setting for backoff delay time is 1 second if you reach 35 out of 40 calls. If you hit the limit, Shopify will return a 429 error, and by default, this module will have a rate limit delay time of 10 seconds. You can modify these options using the following parameters: 

--- a/lib/shopify.js
+++ b/lib/shopify.js
@@ -44,8 +44,8 @@ ShopifyAPI.prototype.conditional_console_log = function(msg) {
     }
 };
 
-ShopifyAPI.prototype.is_valid_signature = function(params) {
-    if(this.config.nonce !== params['state']){
+ShopifyAPI.prototype.is_valid_signature = function(params, non_state) {
+    if(!non_state && this.config.nonce !== params['state']){
         return false;
     }
 

--- a/test/shopify.js
+++ b/test/shopify.js
@@ -92,6 +92,25 @@ describe('#is_valid_signature', function(){
 
         expect(Shopify.is_valid_signature(params)).to.equal(true);
     });
+
+    it('should ignore the state/nonce when non_state is true', function(){
+
+        // Values used below were pre-calculated and not part
+        // of an actual shop.
+
+        var Shopify = shopifyAPI({
+                shopify_shared_secret: 'hush',
+            }),
+            params = {
+                'shop': 'some-shop.myshopify.com',
+                'code': 'a94a110d86d2452eb3e2af4cfb8a3828',
+                'timestamp': '1337178173',
+                'signature': '6e39a2ea9e497af6cb806720da1f1bf3',
+                'hmac': '2cb1a277650a659f1b11e92a4a64275b128e037f2c3390e3c8fd2d8721dac9e2',
+            };
+
+        expect(Shopify.is_valid_signature(params, true)).to.equal(true);
+    });
 });
 
 describe('#exchange_temporary_token', function(){


### PR DESCRIPTION
When the app icon is clicked within the Shopify user's app store it takes the user to the predefined url set in the app's settings, with a set of parameters that do not contain the state (as it's auth only). 

This change allows the re-use of 'is_valid_signature' to validate non-authorisation signatures, by simply ignoring the latest check for `this.config.nonce !== param['state']`

Readme and tests also altered/updated