### PR TITLE
Allow data argument on get requests

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,11 +136,12 @@ function callback(err, data, headers) {
 ### GET
 
 ```js
-Shopify.get('/admin/products.json', function(err, data, headers){
+Shopify.get('/admin/products.json', query_data, function(err, data, headers){
   console.log(data); // Data contains product json information
   console.log(headers); // Headers returned from request
 });
 ```
+The argument `query_data` is optional. If included it will be converted to a querystring and appended to the uri.
 
 ### POST
 

--- a/lib/shopify.js
+++ b/lib/shopify.js
@@ -7,6 +7,7 @@
 
 var crypto = require('crypto');
 var BigJSON = require('json-bigint');
+var querystring = require('querystring');
 
 function ShopifyAPI(config) {
 
@@ -216,6 +217,9 @@ ShopifyAPI.prototype.get = function(endpoint, data, callback) {
     if (typeof data === 'function' && arguments.length < 3) {
         callback = data;
         data = null;
+    } else {
+      endpoint += '?' + querystring.stringify(data);
+      data = null;
     }
     this.makeRequest(endpoint,'GET', data, callback);
 };

--- a/package.json
+++ b/package.json
@@ -29,6 +29,6 @@
   "devDependencies": {
     "mocha": "^1.20.1",
     "chai": "^1.9.1",
-    "nock": "^0.34.1"
+    "nock": "^7.5.0"
   }
 }

--- a/test/shopify.js
+++ b/test/shopify.js
@@ -229,6 +229,30 @@ describe('#get', function(){
        done();
      });
    });
+
+   it('should parse data argument into a querystring and append it to endpoint', function(done) {
+     var shopify_get = nock('https://myshop.myshopify.com')
+                         .get('/admin/products.json')
+												 .query(true)
+                         .reply(200, function(uri, reqBody) {
+                           return {uri: uri};
+                         });
+
+     var Shopify = shopifyAPI({
+       shop: 'myshop',
+       shopify_api_key: 'abc123',
+       shopify_shared_secret: 'asdf1234',
+       shopify_scope: 'write_products',
+       redirect_uri: 'http://localhost:3000/finish_auth',
+       verbose: false
+     });
+
+
+     Shopify.get('/admin/products.json', {page: 2, limit: 15}, function(err, data, headers){
+       expect(data.uri).to.equal('/admin/products.json?page=2&limit=15');
+       done();
+     });
+   });
 });
 
 describe('#post', function(){

--- a/test/shopify.js
+++ b/test/shopify.js
@@ -233,7 +233,7 @@ describe('#get', function(){
    it('should parse data argument into a querystring and append it to endpoint', function(done) {
      var shopify_get = nock('https://myshop.myshopify.com')
                          .get('/admin/products.json')
-												 .query(true)
+                         .query(true)
                          .reply(200, function(uri, reqBody) {
                            return {uri: uri};
                          });


### PR DESCRIPTION
In response to https://github.com/christophergregory/shopify-node-api/issues/26

- Modified #get method to convert `data` argument(if present) to a query string and append it to the endpoint.
- Updated nock version number in package.json for access to nock().get()**.query()**
- Added test
- All tests passed
- Updated README.md

```js
Shopify.get('/admin/products.json', {page: 3, limit: 5}, cb);
// Makes request to endpoint /admin/products.json?page=3&limit=5
```