### PR TITLE
webhook verification

### DIFF
--- a/lib/shopify.js
+++ b/lib/shopify.js
@@ -73,6 +73,26 @@ ShopifyAPI.prototype.is_valid_signature = function(params, non_state) {
     return (digest === hmac);
 };
 
+ShopifyAPI.prototype.is_valid_webhook = function(headers, body){
+    var hmac = headers['x-shopify-hmac-sha256'],
+        kvpairs = [],
+        message,
+        digest;
+
+    message = JSON.stringify(body);
+
+    //Shopify seems to be escaping forward slashes when the build the HMAC
+    // so we need to do the same otherwise it will fail validation
+    // Shopify also seems to replace '&' with \u0026 ...
+    //message = message.replace('/', '\\/');
+    message = message.split('/').join('\\/');
+    message = message.split('&').join('\\u0026');
+
+    digest = crypto.createHmac('SHA256', this.config.shopify_shared_secret).update(message).digest('base64');
+
+    return digest === hmac;
+};
+
 ShopifyAPI.prototype.exchange_temporary_token = function(query_params, callback) {
     var data = {
             client_id: this.config.shopify_api_key,


### PR DESCRIPTION
To verify a webhook from shopify
```
var Shopify = new shopifyAPI(config), // You need to pass in your config here
    headers = req.headers,
    body = req.body;

if(Shopify.is_valid_webhook(headers, body)){
   //do stuff with webhook
}
```

Edit: I found the code https://github.com/jonpulice/node-shopify-auth/blob/master/lib/main.js#L327 and modified it a little bit