### PR TITLE
Add option to throw an Error in case of 429 response code

### DIFF
--- a/README.md
+++ b/README.md
@@ -258,7 +258,8 @@ var config = {
   //...
   rate_limit_delay: 10000, // 10 seconds (in ms) => if Shopify returns 429 response code
   backoff: 35, // limit X of 40 API calls => default is 35 of 40 API calls
-  backoff_delay: 1000 // 1 second (in ms) => wait 1 second if backoff option is exceeded
+  backoff_delay: 1000, // 1 second (in ms) => wait 1 second if backoff option is exceeded
+  throw_error_on_rate_limit: false // if true an Error will be thrown on 429 response code
 }
 ```
 

--- a/lib/shopify.js
+++ b/lib/shopify.js
@@ -155,6 +155,10 @@ ShopifyAPI.prototype.makeRequest = function(endpoint, method, data, callback, re
 
             // If the request is being rate limited by Shopify, try again after a delay
             if (response.statusCode === 429) {
+                if (self.config.throw_error_on_rate_limit) {
+                    return callback(new Error( 'Api rate limit hit' ));
+                }
+
                 return setTimeout(function() {
                     self.makeRequest(endpoint, method, data, callback);
                 }, self.config.rate_limit_delay || 10000 );


### PR DESCRIPTION
Hi there!
In our use case we'd like to have control of retrying a rate limited call, so we added an option to have control over it.
Thanks!