### PR TITLE
API requests don't always return an err for unsuccessful responses

### DIFF
--- a/lib/shopify.js
+++ b/lib/shopify.js
@@ -162,7 +162,7 @@ ShopifyAPI.prototype.makeRequest = function(endpoint, method, data, callback, re
             }
 
             // If the backoff limit is reached, add a delay before executing callback function
-            if (response.statusCode === 200 && self.has_header(response, 'http_x_shopify_shop_api_call_limit')) {
+            if ((response.statusCode >= 200 || response.statusCode <= 299) && self.has_header(response, 'http_x_shopify_shop_api_call_limit')) {
                 var api_limit = parseInt(response.headers['http_x_shopify_shop_api_call_limit'].split('/')[0], 10);
                 if (api_limit >= (self.config.backoff || 35)) delay = self.config.backoff_delay || 1000; // in ms
             }
@@ -175,15 +175,18 @@ ShopifyAPI.prototype.makeRequest = function(endpoint, method, data, callback, re
                 try {
                     if (body.trim() != '') { //on some requests, Shopify retuns an empty body (several spaces)
                         json = BigJSON.parse(body);
-                        if (json.hasOwnProperty('error_description') || json.hasOwnProperty('error') || json.hasOwnProperty('errors')) {
-                            error = {
-                                  error : (json.error_description || json.error || json.errors)
-                                , code  : response.statusCode
-                            };
-                        }
                     }
                 } catch(e) {
                     error = e;
+                }
+                if (response.statusCode >= 400) {
+                    if (json && (json.hasOwnProperty('error_description') || json.hasOwnProperty('error') || json.hasOwnProperty('errors'))) {
+                        var jsonError = (json.error_description || json.error || json.errors);
+                    }
+                    error = {
+                        code: response.statusCode
+                      , error: jsonError || response.statusMessage
+                    };
                 }
 
                 callback(error, json, response.headers, options);


### PR DESCRIPTION
Improved response handling to return errors for all error responses. Sets the error status code for all error responses, attempts to parse out an error message if one is returned in the response body, and falls back to the response status message if no json error is found.

Resolves #75 