### PR TITLE
Update is_valid_signature() to support proxied requests from Shopify

### DIFF
--- a/lib/shopify.js
+++ b/lib/shopify.js
@@ -52,6 +52,7 @@ ShopifyAPI.prototype.is_valid_signature = function(params, non_state) {
     }
 
     var hmac = params['hmac'],
+        theHash = params['hmac'] || params['signature'],
         secret = this.config.shopify_shared_secret,
         parameters = [],
         digest,
@@ -63,14 +64,14 @@ ShopifyAPI.prototype.is_valid_signature = function(params, non_state) {
         }
     }
 
-    message = parameters.sort().join('&');
+    message = parameters.sort().join(hmac ? '&' : '');
 
     digest = crypto
                 .createHmac('SHA256', secret)
                 .update(message)
                 .digest('hex');
 
-    return (digest === hmac);
+    return ( digest === theHash );
 };
 
 ShopifyAPI.prototype.exchange_temporary_token = function(query_params, callback) {


### PR DESCRIPTION
I am writing a Shopify app that will utilize Shopify's application proxy feature.  When validating requests from Shopify, there are two different ways Shopify generates the signature/hmac.  I updated the is_valid_signature() method to support proxied requests from Shopify.

Essentially, when Shopify generates the message for the hash, Shopify uses either an '&' or nothing.

Here are the links that shows the different implementation in Ruby:

- [Join without '&'](https://help.shopify.com/api/tutorials/application-proxies#security)
- [Join with '&'](https://help.shopify.com/api/tutorials/building-public-app#authenticating-with-shopify)