### PR TITLE
added possibilty to create auth url without passing of shopname

### DIFF
--- a/lib/shopify.js
+++ b/lib/shopify.js
@@ -36,6 +36,15 @@ ShopifyAPI.prototype.buildAuthURL = function(){
     return auth_url;
 };
 
+ShopifyAPI.prototype.buildAuthURLWithoutShopName = function(){
+  var auth_url = "https://myshopify.com/admin/oauth/authorize?";
+  auth_url += "client_id=" + this.config.shopify_api_key;
+  auth_url += "&scope=" + this.config.shopify_scope;
+  auth_url += "&redirect_uri=" + this.config.redirect_uri;
+  auth_url += "&state=" + this.config.nonce;
+  return auth_url;
+};
+
 ShopifyAPI.prototype.set_access_token = function(token) {
     this.config.access_token = token;
 };

--- a/lib/shopify.js
+++ b/lib/shopify.js
@@ -27,22 +27,17 @@ function ShopifyAPI(config) {
 }
 
 ShopifyAPI.prototype.buildAuthURL = function(){
-    var auth_url = 'https://' + this.config.shop.split(".")[0];
-    auth_url += ".myshopify.com/admin/oauth/authorize?";
+    var auth_url = 'https://';
+    if(this.config.shop) {
+      auth_url += this.config.shop.split(".")[0];
+      auth_url += ".";
+    }
+    auth_url += "myshopify.com/admin/oauth/authorize?";
     auth_url += "client_id=" + this.config.shopify_api_key;
     auth_url += "&scope=" + this.config.shopify_scope;
     auth_url += "&redirect_uri=" + this.config.redirect_uri;
     auth_url += "&state=" + this.config.nonce;
     return auth_url;
-};
-
-ShopifyAPI.prototype.buildAuthURLWithoutShopName = function(){
-  var auth_url = "https://myshopify.com/admin/oauth/authorize?";
-  auth_url += "client_id=" + this.config.shopify_api_key;
-  auth_url += "&scope=" + this.config.shopify_scope;
-  auth_url += "&redirect_uri=" + this.config.redirect_uri;
-  auth_url += "&state=" + this.config.nonce;
-  return auth_url;
 };
 
 ShopifyAPI.prototype.set_access_token = function(token) {

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "shopify-node-api",
+  "name": "@walkthechat/shopify-node-api",
   "version": "1.8.1",
   "description": "OAuth2 Module for Shopify API",
   "main": "./lib/shopify",
@@ -8,7 +8,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/sinechris/shopify-node-api.git"
+    "url": "https://github.com/WalktheChat/shopify-node-api"
   },
   "keywords": [
     "Shopify",
@@ -21,7 +21,7 @@
   "bugs": {
     "url": "https://github.com/sinechris/shopify-node-api/issues"
   },
-  "homepage": "https://github.com/sinechris/shopify-node-api",
+  "homepage": "https://github.com/WalktheChat/shopify-node-api",
   "dependencies": {
     "json-bigint": "^0.1.4"
   },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "shopify-node-api",
-  "version": "1.8.0",
+  "version": "1.8.1",
   "description": "OAuth2 Module for Shopify API",
   "main": "./lib/shopify",
   "scripts": {

--- a/test/shopify.js
+++ b/test/shopify.js
@@ -25,23 +25,34 @@ describe('Constructor Function: #shopifyAPI', function(){
 });
 
 describe('#buildAuthURL', function(){
+    it('builds correct string with supplied shop', function(){
+        var Shopify = new shopifyAPI({
+          shop: 'MYSHOP',
+          shopify_api_key: 'abc123',
+          shopify_shared_secret: 'asdf1234',
+          shopify_scope: 'write_products',
+          redirect_uri: 'http://localhost:3000/finish_auth',
+          nonce: 'abc123'
+        });
 
-    var Shopify = new shopifyAPI({
-                shop: 'MYSHOP',
-                shopify_api_key: 'abc123',
-                shopify_shared_secret: 'asdf1234',
-                shopify_scope: 'write_products',
-                redirect_uri: 'http://localhost:3000/finish_auth',
-                nonce: 'abc123'
-            });
-
-
-    it('builds correct string', function(){
         var auth_url = Shopify.buildAuthURL(),
             correct_auth_url = 'https://MYSHOP.myshopify.com/admin/oauth/authorize?client_id=abc123&scope=write_products&redirect_uri=http://localhost:3000/finish_auth&state=abc123';
         auth_url.should.equal(correct_auth_url);
     });
 
+    it('builds correct string without supplied shop', function(){
+        var Shopify = new shopifyAPI({
+          shopify_api_key: 'abc123',
+          shopify_shared_secret: 'asdf1234',
+          shopify_scope: 'write_products',
+          redirect_uri: 'http://localhost:3000/finish_auth',
+          nonce: 'abc123'
+        });
+
+        var auth_url = Shopify.buildAuthURL(),
+          correct_auth_url = 'https://myshopify.com/admin/oauth/authorize?client_id=abc123&scope=write_products&redirect_uri=http://localhost:3000/finish_auth&state=abc123';
+        auth_url.should.equal(correct_auth_url);
+    });
 });
 
 describe('#set_access_token', function(){


### PR DESCRIPTION
in some cases we dont want to pass a shopname explicitly for oauth login. in this case we can just add myshopify.com as base url for the oauth request, it will automatically select the most recent login to a shopify shop for auth