### PR TITLE
Ability to Limit Logging

### DIFF
--- a/README.md
+++ b/README.md
@@ -214,6 +214,32 @@ var config = {
 }
 ```
 
+##### Additional Verbose Options
+
+If only a particular message type(s) is desired it may be specifically requested
+to override the standard verbose console logging.
+
+Available logging options:
+    * verbose_status
+    * verbose_headers
+    * verbose_api_limit
+    * verbose_body
+
+    ```js
+    var config = {
+      ...
+      verbose_headers: true,
+      verbose_api_limit: true
+    }
+    ```
+
+    The above config results in only messages beginning as type *HEADER:* and *API_LIMIT:*
+    to be logged.
+
+    This is a more ideal use case for a production server, where excessive
+    body content logging may obstruct developers from isolating meaningful server
+    data.
+
 ### Verify Shopify Request
 
 **Note**: *This module has been updated to use HMAC parameter instead of the deprecated "signature"*.

--- a/README.md
+++ b/README.md
@@ -225,20 +225,20 @@ Available logging options:
     * verbose_api_limit
     * verbose_body
 
-    ```js
-    var config = {
-      ...
-      verbose_headers: true,
-      verbose_api_limit: true
-    }
-    ```
+```js
+var config = {
+  ...
+  verbose_headers: true,
+  verbose_api_limit: true
+}
+```
 
-    The above config results in only messages beginning as type **HEADER:** and
-    **API_LIMIT:** to be logged.
+The above config results in only messages beginning as type __HEADER:__ and
+__API_LIMIT:__ to be logged.
 
-    This is a more ideal use case for a production server, where excessive
-    body content logging may obstruct developers from isolating meaningful server
-    data.
+This is a more ideal use case for a production server, where excessive
+body content logging may obstruct developers from isolating meaningful server
+data.
 
 ### Verify Shopify Request
 

--- a/README.md
+++ b/README.md
@@ -233,8 +233,8 @@ Available logging options:
     }
     ```
 
-    The above config results in only messages beginning as type *HEADER:* and *API_LIMIT:*
-    to be logged.
+    The above config results in only messages beginning as type **HEADER:** and
+    **API_LIMIT:** to be logged.
 
     This is a more ideal use case for a production server, where excessive
     body content logging may obstruct developers from isolating meaningful server

--- a/lib/shopify.js
+++ b/lib/shopify.js
@@ -41,9 +41,11 @@ ShopifyAPI.prototype.set_access_token = function(token) {
 };
 
 ShopifyAPI.prototype.conditional_console_log = function(msg) {
-    if (this.config.verbose) {
-        console.log( msg );
-    }
+   if (this.config.verbose) {
+       if ( !( /^BODY:/.test(msg) ) ) {
+           console.log( msg );
+       }
+   }
 };
 
 ShopifyAPI.prototype.is_valid_signature = function(params, non_state) {

--- a/lib/shopify.js
+++ b/lib/shopify.js
@@ -24,6 +24,19 @@ function ShopifyAPI(config) {
         this.config.verbose = true;
     }
 
+    // If any condition below is true assume the user does not want all logging
+    if (this.config.verbose_status === true){
+        this.config.verbose = false;
+    }
+    if (this.config.verbose_headers === true){
+        this.config.verbose = false;
+    }
+    if (this.config.verbose_api_limit === true){
+        this.config.verbose = false;
+    }
+    if (this.config.verbose_body === true){
+        this.config.verbose = false;
+    }
 }
 
 ShopifyAPI.prototype.buildAuthURL = function(){
@@ -41,11 +54,27 @@ ShopifyAPI.prototype.set_access_token = function(token) {
 };
 
 ShopifyAPI.prototype.conditional_console_log = function(msg) {
+
    if (this.config.verbose) {
-       if ( !( /^BODY:/.test(msg) ) ) {
+       console.log( msg );
+   }
+
+   // If any message type condition below is met show that message
+   else {
+       if (this.config.verbose_status === true && /^STATUS:/.test(msg) ){
+           console.log( msg );
+       }
+       if (this.config.verbose_headers === true && /^HEADERS:/.test(msg)){
+           console.log( msg );
+       }
+       if (this.config.verbose_api_limit === true && /^API_LIMIT:/.test(msg)){
+           console.log( msg );
+       }
+       if (this.config.verbose_body === true && /^BODY:/.test(msg)){
            console.log( msg );
        }
    }
+
 };
 
 ShopifyAPI.prototype.is_valid_signature = function(params, non_state) {

--- a/lib/shopify.js
+++ b/lib/shopify.js
@@ -54,11 +54,9 @@ ShopifyAPI.prototype.set_access_token = function(token) {
 };
 
 ShopifyAPI.prototype.conditional_console_log = function(msg) {
-
    if (this.config.verbose) {
        console.log( msg );
    }
-
    // If any message type condition below is met show that message
    else {
        if (this.config.verbose_status === true && /^STATUS:/.test(msg) ){
@@ -74,7 +72,6 @@ ShopifyAPI.prototype.conditional_console_log = function(msg) {
            console.log( msg );
        }
    }
-
 };
 
 ShopifyAPI.prototype.is_valid_signature = function(params, non_state) {


### PR DESCRIPTION
This PR will allow users to limit logging to messages with types they deem important within their config.

PURPOSE:
On my production server I would like to see logged data on api rate usage so I can determine if an error is caused by a usage spike. However, leaving verbose mode on floods my logs with logged body content to the point that it is hard to extract any meaningful server messages from my logs.