### PR TITLE
Limit aware

### DIFF
--- a/README.md
+++ b/README.md
@@ -262,6 +262,17 @@ var config = {
 }
 ```
 
+Alternatively if you are working on a Shopify Plus or Gold project or if you get increased API limits from your Shopify rep you can use 'backoff_level' to specify at what fraction of bucket capacity your app should start backing off.
+
+```js
+var config = {
+  //...
+  rate_limit_delay: 10000, // 10 seconds (in ms) => if Shopify returns 429 response code
+  backoff_level: 0.85, // limit X/bucket size API calls => no default since 'backoff' is the default behaviour
+  backoff_delay: 1000 // 1 second (in ms) => wait 1 second if backoff option is exceeded
+}
+```
+
 # Become a Shopify App Developer
 
 [Join the Shopify Partner Program](https://app.shopify.com/services/partners/signup?ref=grenadeapps)

--- a/lib/shopify.js
+++ b/lib/shopify.js
@@ -20,6 +20,10 @@ function ShopifyAPI(config) {
 
     this.config = config;
 
+    if(this.config.backoff_level){
+        this.config.backoff_level = parseFloat(this.config.backoff_level);
+    }
+
     if (this.config.verbose !== false){
         this.config.verbose = true;
     }
@@ -164,8 +168,21 @@ ShopifyAPI.prototype.makeRequest = function(endpoint, method, data, callback, re
 
             // If the backoff limit is reached, add a delay before executing callback function
             if ((response.statusCode >= 200 || response.statusCode <= 299) && self.has_header(response, 'http_x_shopify_shop_api_call_limit')) {
-                var api_limit = parseInt(response.headers['http_x_shopify_shop_api_call_limit'].split('/')[0], 10);
-                if (api_limit >= (self.config.backoff || 35)) delay = self.config.backoff_delay || 1000; // in ms
+                var api_limit_parts = response.headers['http_x_shopify_shop_api_call_limit'].split('/');
+
+                var api_limit = parseInt(api_limit_parts[0], 10);
+                var api_max = parseInt(api_limit_parts[1], 10); // 40 on standard shopify accounts
+                var limit_rate = false;
+                if(self.config.backoff_level){
+                    var used_api = api_limit / api_max;
+                    limit_rate = (used_api > self.config.backoff_level);
+                    self.conditional_console_log('FRACTION_USED: '+ used_api +' of '+ self.config.backoff_level);
+                }else limit_rate = (api_limit >= (self.config.backoff || 35));
+
+                if(limit_rate){
+                    self.conditional_console_log('RATE DELAY: '+ api_limit +' of '+ api_max);
+                    delay = self.config.backoff_delay || 1000; // in ms
+                } 
             }
 
             setTimeout(function(){

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "shopify-node-api",
-  "version": "1.8.0",
+  "version": "1.8.1",
   "description": "OAuth2 Module for Shopify API",
   "main": "./lib/shopify",
   "scripts": {
@@ -8,7 +8,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/sinechris/shopify-node-api.git"
+    "url": "https://github.com/BKnights/shopify-node-api.git"
   },
   "keywords": [
     "Shopify",
@@ -19,9 +19,9 @@
   "author": "Chris Gregory <chris@sinelabs.com> (http://sinelabs.com/)",
   "license": "MIT",
   "bugs": {
-    "url": "https://github.com/sinechris/shopify-node-api/issues"
+    "url": "https://github.com/BKnights/shopify-node-api/issues"
   },
-  "homepage": "https://github.com/sinechris/shopify-node-api",
+  "homepage": "https://github.com/BKnights/shopify-node-api",
   "dependencies": {
     "json-bigint": "^0.1.4"
   },


### PR DESCRIPTION
Added decimal fraction for backoff level. Shopify Plus and Gold accounts have a bucket size greater than 40 and it's also possible to ask Shopify to increase the api limit for an account on an API key basis. 