### PR TITLE
Add Graphql support

### DIFF
--- a/lib/shopify.js
+++ b/lib/shopify.js
@@ -240,7 +240,7 @@ ShopifyAPI.prototype.makeRequest = function(endpoint, method, data, callback, re
                         code: response.statusCode
                       , error: jsonError || response.statusMessage
                     };
-                }
+                  }
 
                   return callback(error, json, response.headers, options);
                 }
@@ -322,6 +322,10 @@ ShopifyAPI.prototype.patch = function(endpoint, data, callback) {
 
 ShopifyAPI.prototype.has_header = function(response, header) {
     return response.headers.hasOwnProperty(header) ? true : false;
+};
+
+ShopifyAPI.prototype.graphql = function(data, callback) {
+  this.makeRequest('/admin/api/graphql.json','POST', data, callback);
 };
 
 module.exports = ShopifyAPI;

--- a/test/shopify.js
+++ b/test/shopify.js
@@ -740,7 +740,7 @@ describe('#graphql', function(){
               verbose: false
           });
 
-      Shopify.post('/admin/api/graphql.json', graphql_data, function(err, data, headers){
+      Shopify.graphql(graphql_data, function(err, data, headers){
           expect(data).to.deep.equal(response);
           done();
       });

--- a/test/shopify.js
+++ b/test/shopify.js
@@ -700,3 +700,49 @@ describe('#delete', function(){
 
     });
 });
+
+describe('#graphql', function(){
+  it('should return correct response', function(done){
+
+      var graphql_data = {
+            query: '{shop{id}}',
+            variables: {}
+          }
+          response = {
+            data: {
+              shop: {
+                id: 'gid:\/\/shopify\/Shop\/1234567'
+              }
+            },
+            extensions: {
+              cost: {
+                requestedQueryCost: 1,
+                actualQueryCost: 1,
+                throttleStatus: {
+                  maximumAvailable: 1000.0,
+                  currentlyAvailable: 999,
+                  restoreRate: 50.0
+                }
+              }
+            }
+          };
+
+      var shopify_get = nock('https://myshop.myshopify.com')
+                          .post('/admin/api/graphql.json')
+                          .reply(200, response);
+
+      var Shopify = shopifyAPI({
+              shop: 'myshop',
+              shopify_api_key: 'abc123',
+              shopify_shared_secret: 'asdf1234',
+              shopify_scope: 'write_products',
+              redirect_uri: 'http://localhost:3000/finish_auth',
+              verbose: false
+          });
+
+      Shopify.post('/admin/api/graphql.json', graphql_data, function(err, data, headers){
+          expect(data).to.deep.equal(response);
+          done();
+      });
+  });
+});


### PR DESCRIPTION
Adds basic support for GraphQL queries and mutations in service of #100:

```js
var shopifyAPI = require('shopify-node-api');

var Shopify = new shopifyAPI({
  shop: 'anprichter-test',
  shopify_api_key: '1b89be6b5198a41199ed5a52d804792d',
  access_token: '00f4a91c8f88268d23946233d8ce5d1c'
});

var query = `
mutation productUpdate($input: ProductInput!) {
  productUpdate(input: $input) {
    product {
      id
    }
    userErrors {
      field
      message
    }
  }
}
`;

var variables = {
	"input": {
		"id": "gid://shopify/Product/1326527184952",
		"variants": [
			{
				"price": 10,
				"title": "foobar",
				"options": [
					"foo",
					"bar",
					"baz"
				]
			},
			{
				"price": 20,
				"title": "baz",
				"options": [
					"one",
					"two",
					"three"
				]
			}
		]
	}
};

var response = Shopify.graphql({"query": query, "variables": variables});
```

Tests are passing.

I noticed an issue that I'm not certain is with my local environment or the project itself to do with the added gzip support, but I'll make an issue for that. My changes do not appear to contribute to it.